### PR TITLE
Fix: issue running tests without stacktrace

### DIFF
--- a/test/CryptoSEO_creation_test.js
+++ b/test/CryptoSEO_creation_test.js
@@ -133,11 +133,11 @@ contract('CryptoSEO commitment creation', accounts => {
   describe('#createSEOCommitment without LINK approval', () => {
     context('when called without having approved LINK', () => {
       it('fails to create the commitment', async () => {
-        await expectRevert(cc.createSEOCommitment(validCommitment.site, validCommitment.searchTerm, validCommitment.domainMatch, validCommitment.initialSearchRank,
+        await expectRevert.unspecified(cc.createSEOCommitment(validCommitment.site, validCommitment.searchTerm, validCommitment.domainMatch, validCommitment.initialSearchRank,
           validCommitment.amtPerRankEth, validCommitment.maxPayableEth, validCommitment.timeToExecute, validCommitment.payee, {
             from: defaultAccount,
             value: validCommitment.maxPayableEth
-          }), "Error: Revert or exceptional halt")
+          }))
       })
     })
   })

--- a/test/CryptoSEO_fulfillment_test.js
+++ b/test/CryptoSEO_fulfillment_test.js
@@ -212,8 +212,8 @@ contract('CryptoSEO commitment fulfillment', accounts => {
         const receipt = await cc.withdrawPayout({from: defaultAccount})
         const afterBal = new BN(await web3.eth.getBalance(defaultAccount))
 
-        const tx = await web3.eth.getTransaction(receipt.transactionHash)
-        const txCost = new BN(tx.gasPrice * receipt.cumulativeGasUsed)
+        const tx = await web3.eth.getTransaction(receipt.tx)
+        const txCost = new BN(tx.gasPrice * receipt.receipt.cumulativeGasUsed)
 
         assert.equal(afterBal.toString(), beforeBal.add(payout).sub(txCost).toString())        
       })

--- a/test/CryptoSEO_rerun_test.js
+++ b/test/CryptoSEO_rerun_test.js
@@ -97,7 +97,7 @@ contract('CryptoSEO rerun', accounts => {
         let requestEvent = (await cc.getPastEvents('RequestGoogleSearchSent'))[0]
         let reqId = requestEvent.returnValues.requestId
         await time.increase((60 * 60 * 24 * 31))
-        await expectRevert(cc.rerunExpiredRequest(reqId), "Error: Revert or exceptional halt")
+        await expectRevert.unspecified(cc.rerunExpiredRequest(reqId))
       })
     })
 

--- a/test/CryptoSEO_simple_test.js
+++ b/test/CryptoSEO_simple_test.js
@@ -125,8 +125,8 @@ contract('CryptoSEO simple', accounts => {
         const receipt = await cc.withdrawEther({ from: consumer })
         const afterBal = new BN(await web3.eth.getBalance(consumer))
 
-        const tx = await web3.eth.getTransaction(receipt.transactionHash)
-        const txCost = new BN(tx.gasPrice * receipt.cumulativeGasUsed)
+        const tx = await web3.eth.getTransaction(receipt.tx)
+        const txCost = new BN(tx.gasPrice * receipt.receipt.cumulativeGasUsed)
 
         assert.equal(afterBal.toString(), beforeBal.add(new BN(payment)).sub(txCost).toString())
       })


### PR DESCRIPTION
Seems like the response from tx execution on Truffle contracts is different when running with or without '--stacktrace'. This ensures the tests pass WITHOUT '--stacktrace' for the time being.