### PR TITLE
Add more functions to view tab

### DIFF
--- a/src/js/create.js
+++ b/src/js/create.js
@@ -1,37 +1,11 @@
 import React, { Component } from 'react'
 import 'bootstrap/dist/css/bootstrap.min.css'
 import Button from 'react-bootstrap/Button'
-import { Container, Form, Card, Modal, Spinner, Col, InputGroup } from 'react-bootstrap'
+import { Container, Form, Card, Col, InputGroup } from 'react-bootstrap'
+import ModalDialog from './modal'
+
 const LINK_TOKEN_MULTIPLIER = 10**18
 const ORACLE_PAYMENT = 1 * LINK_TOKEN_MULTIPLIER
-
-function ModalDialog(props) {
-    return (
-      <>
-        <Modal show={props.modal.show} onHide={props.handleClose}>
-          <Modal.Header closeButton>
-            <Modal.Title>{props.modal.title}</Modal.Title>
-          </Modal.Header>
-          <Modal.Body>{props.modal.message}</Modal.Body>
-          <Modal.Footer>
-            {props.modal.secondaryBtn ?
-            <Button variant="secondary" onClick={props.handleClose}>
-              {props.modal.secondaryBtn.text}
-            </Button>
-            : <></>}
-            {props.modal.primaryBtn ?
-            <Button variant="primary" onClick={props.modal.primaryBtn.fn ? props.modal.primaryBtn.fn : props.handleClose}>
-              {props.modal.primaryBtn.text}
-            </Button>
-            : <></>}
-            {props.modal.spinner ?
-            <Spinner animation="border" />
-            : <></>}
-          </Modal.Footer>
-        </Modal>
-      </>
-    );
-}
 
 export default class Create extends Component {
     constructor(props){

--- a/src/js/create.js
+++ b/src/js/create.js
@@ -172,13 +172,13 @@ export default class Create extends Component {
 
      createCommitment = () => {
        let timeNow = Math.floor(Date.now() / 1000)
-       let expiryTime = 0
+       let timeToExecute = 0
        if (this.state.durationUnits == "Minutes") {
-         expiryTime = timeNow + this.state.durationAmt * 60
+        timeToExecute = timeNow + this.state.durationAmt * 60
        } else if (this.state.durationUnits == "Hours") {
-         expiryTime = timeNow + this.state.durationAmt * 60 * 60
+        timeToExecute = timeNow + this.state.durationAmt * 60 * 60
        } else if (this.state.durationUnits == "Days") {
-         expiryTime = timeNow + this.state.durationAmt * 60 * 60 * 24
+        timeToExecute = timeNow + this.state.durationAmt * 60 * 60 * 24
        } else {
          console.error("Unknown unit type")
          return
@@ -191,7 +191,7 @@ export default class Create extends Component {
          initialSearchRank: parseInt(this.state.initialSearchRank),
          amtPerRankEth: this.web3.utils.toWei(this.state.amtPerRankEth, "ether"),
          maxAmtEth: this.web3.utils.toWei(this.state.maxAmtEth, "ether"),
-         expiryTime: expiryTime,
+         timeToExecute: timeToExecute,
          payee: this.state.payee
        }
  
@@ -241,7 +241,7 @@ export default class Create extends Component {
       }
        
        this.getEth().CryptoSEOContract.methods.createSEOCommitment(callObj.site, callObj.searchTerm, callObj.domainMatch,
-         callObj.initialSearchRank, callObj.amtPerRankEth, callObj.maxAmtEth, callObj.expiryTime, callObj.payee).send( 
+         callObj.initialSearchRank, callObj.amtPerRankEth, callObj.maxAmtEth, callObj.timeToExecute, callObj.payee).send( 
          {value: callObj.maxAmtEth, from: this.getEth().currentAccount})
          .once('transactionHash', onWaiting)
          .on('error', onError)

--- a/src/js/modal.js
+++ b/src/js/modal.js
@@ -1,0 +1,32 @@
+import React from 'react'
+import 'bootstrap/dist/css/bootstrap.min.css'
+import Button from 'react-bootstrap/Button'
+import { Modal, Spinner } from 'react-bootstrap'
+
+export default function ModalDialog(props) {
+    return (
+      <>
+        <Modal show={props.modal.show} onHide={props.handleClose}>
+          <Modal.Header closeButton>
+            <Modal.Title>{props.modal.title}</Modal.Title>
+          </Modal.Header>
+          <Modal.Body>{props.modal.message}</Modal.Body>
+          <Modal.Footer>
+            {props.modal.secondaryBtn ?
+            <Button variant="secondary" onClick={props.handleClose}>
+              {props.modal.secondaryBtn.text}
+            </Button>
+            : <></>}
+            {props.modal.primaryBtn ?
+            <Button variant="primary" onClick={props.modal.primaryBtn.fn ? props.modal.primaryBtn.fn : props.handleClose}>
+              {props.modal.primaryBtn.text}
+            </Button>
+            : <></>}
+            {props.modal.spinner ?
+            <Spinner animation="border" />
+            : <></>}
+          </Modal.Footer>
+        </Modal>
+      </>
+    );
+}

--- a/src/js/view.js
+++ b/src/js/view.js
@@ -150,6 +150,7 @@ export default class View extends Component {
 
     rerunCommitment = () => {
         console.log("Rerunning...")
+        //TODO: rerun commitment and refresh page
     }
 
     displayWithdraw = () => {
@@ -160,14 +161,15 @@ export default class View extends Component {
                 <Card.Body>
                     You have <b>{this.web3.utils.fromWei(this.state.curPayout)} ETH</b> to withdraw from this contract.
                     <br/><br/>
-                    <Button variant="primary" onClick={this.rerunCommitment}>Withdraw</Button>
+                    <Button variant="primary" onClick={this.withdrawPayout}>Withdraw</Button>
                 </Card.Body>
             </Card>
         ) 
     }
 
     withdrawPayout = () => {
-        console.log("Withdrawing payout...")
+        this.getEth().CryptoSEOContract.methods.withdrawPayout().send({from: this.getEth().currentAccount})
+        //TODO: refresh the page after the transaction is confirmed
     }
 
     render(){

--- a/src/js/view.js
+++ b/src/js/view.js
@@ -27,51 +27,45 @@ export default class View extends Component {
         this.setState({...this.state, [evt.target.name]: value})
     }
 
-    lookupSeoCommitment = () => {
+    lookupSeoCommitment = async () => {
         this.setState({seoCommitment: null})
         let id = parseInt(this.state.seoCommitmentId)
-        if (!isNaN(id)) {
-            this.getEth().CryptoSEOContract.methods.seoCommitmentList(id).call(
-                {from: this.getEth().currentAccount})
-                .then((resp) => {
-                let commitment = {}
-                Object.keys(resp)
-                    .filter((key) => isNaN(parseInt(key)))
-                    .forEach((key) => commitment[key] = resp[key])
-            
-                this.setState({
-                    seoCommitment: commitment
-                })
-                })
-        }
+        if (isNaN(id)) return
+
+        let resp = await this.getEth().CryptoSEOContract.methods.seoCommitmentList(id).call(
+            {from: this.getEth().currentAccount})
+
+        let commitment = {}
+        Object.keys(resp)
+            .filter((key) => isNaN(parseInt(key)))
+            .forEach((key) => commitment[key] = resp[key])
+    
+        this.setState({
+            seoCommitment: commitment
+        })
     }
 
     displaySEOCommitment = () => {
-        if (!this.state.seoCommitment.isValue) {
-            return (
-                <Form>No SEO Commitment found for that ID</Form>
-            )
-        } else {
-            return (
-                <Table bordered hover size="sm">
-                    <tbody>
-                        <tr key="seoCommitmentId">
-                            <td><b>seoCommitmentId</b></td>
-                            <td>{this.state.seoCommitmentId}</td>
-                        </tr>
-                        {Object.keys(this.state.seoCommitment).filter((k) => k != "isValue").map((field) => {
-                            let val = this.state.seoCommitment[field]
-                            return (
-                                <tr key={field}>
-                                    <td><b>{field}</b></td>
-                                    <td>{this.displayVal(field, val)}</td>
-                                </tr>
-                            )
-                        })}
-                    </tbody>
-                </Table>
-            )
-        }
+        if (!this.state.seoCommitment.isValue) return (<Form>No SEO Commitment found for that ID</Form>)
+        return (
+            <Table bordered hover size="sm">
+                <tbody>
+                    <tr key="seoCommitmentId">
+                        <td><b>seoCommitmentId</b></td>
+                        <td>{this.state.seoCommitmentId}</td>
+                    </tr>
+                    {Object.keys(this.state.seoCommitment).filter((k) => k != "isValue").map((field) => {
+                        let val = this.state.seoCommitment[field]
+                        return (
+                            <tr key={field}>
+                                <td><b>{field}</b></td>
+                                <td>{this.displayVal(field, val)}</td>
+                            </tr>
+                        )
+                    })}
+                </tbody>
+            </Table>
+        )
     }
 
     displayVal = (field, val) => {
@@ -89,9 +83,8 @@ export default class View extends Component {
         }
     }
   
-    render(){
-      return (
-        <Container fluid="xl">
+    displaySearch = () => {
+        return (
             <Card>
                 <Card.Header>Search</Card.Header>
                 <Card.Body>
@@ -107,15 +100,60 @@ export default class View extends Component {
                     }
                 </Card.Body>
             </Card>
-            {!this.state.seoCommitment 
-                ?   <></> 
-                :   <Card>
-                        <Card.Header>SEO Commitment</Card.Header>
-                        <Card.Body>
-                            {this.displaySEOCommitment()}                       
-                        </Card.Body>
-                    </Card>
-            }
+        )
+    }
+
+    displayCommitment = () => {
+        if (!this.state.seoCommitment) return (<></>)
+        return (
+            <>
+                <Card>
+                    <Card.Header>SEO Commitment</Card.Header>
+                    <Card.Body>
+                        {this.displaySEOCommitment()}
+                    </Card.Body>
+                </Card>
+                {this.displayRerun()}
+                {this.displayWithdraw()}
+            </>
+        )
+    }
+
+    displayRerun = () => {
+        if (this.canRerun()) {
+            return (
+                <Card>
+                    <Card.Header>Rerun expired request</Card.Header>
+                    <Card.Body>
+                        It appears the 
+                    </Card.Body>
+                </Card>
+            )            
+        } else {
+            return (<></>)
+        }
+    }
+
+    canRerun = () => {
+        return true
+    }
+
+    displayWithdraw = () => {
+        return (
+            <Card>
+                <Card.Header>Withdraw payout</Card.Header>
+                <Card.Body>
+                    It appears this commitment has expired. In order to rer
+                </Card.Body>
+            </Card>
+        ) 
+    }
+
+    render(){
+      return (
+        <Container fluid="xl">
+            {this.displaySearch()}
+            {this.displayCommitment()}
         </Container>
       )
     }

--- a/test/CryptoSEO_creation_test.js
+++ b/test/CryptoSEO_creation_test.js
@@ -156,7 +156,6 @@ contract('CryptoSEO commitment creation', accounts => {
       it('executes the commitment', async () => {
         let requestEvent = (await cc.getPastEvents('RequestGoogleSearchSent'))[0]
         assert.equal(requestEvent.returnValues.commitmentId, 0)
-        assert.equal(requestEvent.returnValues.timeToExecute, validCommitment.timeToExecute)
 
         let reqId = requestEvent.returnValues.requestId
         assert.equal(reqId.length, 66)
@@ -165,7 +164,9 @@ contract('CryptoSEO commitment creation', accounts => {
         let searchReq = await cc.requestMap(reqId)
         assert.equal(searchReq.isValue, true)
         assert.equal(searchReq.commitmentId, 0)
-        assert.equal(searchReq.timeToExecute, validCommitment.timeToExecute)
+
+        let comt = await cc.seoCommitmentList(0)
+        assert.equal(comt.requestId, reqId)
       })
     })
   })

--- a/test/CryptoSEO_fulfillment_test.js
+++ b/test/CryptoSEO_fulfillment_test.js
@@ -84,6 +84,7 @@ contract('CryptoSEO commitment fulfillment', accounts => {
         let comt = await cc.seoCommitmentList(0)
         assert.equal(comt.isValue, true)
         assert.equal(comt.status, statusCodes.indexOf("Completed"))
+        assert.equal(comt.requestId, 0)
       })
     })
 
@@ -113,7 +114,8 @@ contract('CryptoSEO commitment fulfillment', accounts => {
 
         let comt = await cc.seoCommitmentList(0)
         assert.equal(comt.isValue, true)
-        assert.equal(comt.status, statusCodes.indexOf("Completed"))        
+        assert.equal(comt.status, statusCodes.indexOf("Completed"))
+        assert.equal(comt.requestId, 0)
       })
     })
 
@@ -147,7 +149,8 @@ contract('CryptoSEO commitment fulfillment', accounts => {
 
         let comt = await cc.seoCommitmentList(0)
         assert.equal(comt.isValue, true)
-        assert.equal(comt.status, statusCodes.indexOf("Completed"))        
+        assert.equal(comt.status, statusCodes.indexOf("Completed"))
+        assert.equal(comt.requestId, 0)
       })
     })
     
@@ -178,7 +181,8 @@ contract('CryptoSEO commitment fulfillment', accounts => {
 
         let comt = await cc.seoCommitmentList(0)
         assert.equal(comt.isValue, true)
-        assert.equal(comt.status, statusCodes.indexOf("Completed"))        
+        assert.equal(comt.status, statusCodes.indexOf("Completed"))
+        assert.equal(comt.requestId, 0)
       })
     })
   })


### PR DESCRIPTION
This covers a few changes:
* Update rerunExpiredCommitment in the CryptoSEO contract to run on commitment ID instead of request ID
* Adding the 'rerun' button to the view tab when relevant so users can rerun expired commitments, with accompanying dialogs for LINK payment.
* Adding the 'withdraw' button so that accounts that have ETH waiting to be withdrawn can do so.