### PR TITLE
Remove need for custom chainlink job

### DIFF
--- a/googleSearchAdapter/app.js
+++ b/googleSearchAdapter/app.js
@@ -15,4 +15,12 @@ app.post('/request', (req, res) => {
   })
 })
 
+app.get('/search', (req, res) => {
+  console.log('GET Data: ', req.query)
+  createRequest({id:0, data: req.query}, (status, result) => {
+    console.log('Result: ', result)
+    res.status(status).json(result)
+  })  
+})
+
 app.listen(port, () => console.log(`Listening on port ${port}!`))

--- a/googleSearchAdapter/index.js
+++ b/googleSearchAdapter/index.js
@@ -66,32 +66,16 @@ const createRequest = (input, callback) => {
     })
 }
 
-// This is a wrapper to allow the function to work with
-// GCP Functions
-exports.gcpservice = (req, res) => {
-  createRequest(req.body, (statusCode, data) => {
-    res.status(statusCode).send(data)
-  })
-}
-
-// This is a wrapper to allow the function to work with
-// AWS Lambda
-exports.handler = (event, context, callback) => {
-  createRequest(event, (statusCode, data) => {
-    callback(null, data)
-  })
-}
-
-// This is a wrapper to allow the function to work with
-// newer AWS Lambda implementations
-exports.handlerv2 = (event, context, callback) => {
-  createRequest(JSON.parse(event.body), (statusCode, data) => {
+// This method is used by AWS Lambda to handle both GETs and POSTs
+exports.dosearch = (event, context, callback) => {
+  let reqData = event.httpMethod == "POST" ? JSON.parse(event.body) : {id:0, data: event.queryStringParameters}
+  createRequest(reqData, (statusCode, data) => {
     callback(null, {
       statusCode: statusCode,
       body: JSON.stringify(data),
       isBase64Encoded: false
     })
-  })
+  })  
 }
 
 // This allows the function to be exported for testing

--- a/googleSearchAdapter/serverless.yml
+++ b/googleSearchAdapter/serverless.yml
@@ -59,12 +59,15 @@ provider:
 #    - exclude-me-dir/**
 
 functions:
-  search:
-    handler: index.handlerv2
+  getsearch:
+    handler: index.dosearch
     events:
       - http:
           path: /request
-          method: post     
+          method: post
+      - http:
+          path: /search
+          method: get                
           
 #    The following are a few example events you can configure
 #    NOTE: Please make sure to change your handler code to work with those events

--- a/migrations/1_deploy_cryptoseo.js
+++ b/migrations/1_deploy_cryptoseo.js
@@ -1,6 +1,7 @@
 const CryptoSEO = artifacts.require("CryptoSEO")
 const { LinkToken } = require('@chainlink/contracts/truffle/v0.4/LinkToken')
 const { Oracle } = require('@chainlink/contracts/truffle/v0.6/Oracle')
+require('dotenv').config();
 
 module.exports = async (deployer, network, [defaultAccount]) => {
   if (network == "test") {
@@ -10,12 +11,17 @@ module.exports = async (deployer, network, [defaultAccount]) => {
     try {
       await deployer.deploy(LinkToken, { from: defaultAccount })
       await deployer.deploy(Oracle, LinkToken.address, { from: defaultAccount })
-      await deployer.deploy(CryptoSEO, LinkToken.address, Oracle.address, "000")
+      await deployer.deploy(CryptoSEO, LinkToken.address, Oracle.address, "000", "001", "http://test.com")
     } catch (err) {
       console.error(err)
     }
   } else {
     //TODO: Put the Oracle address and Job ID somewhere in config (this is for Rinkeby)
-    deployer.deploy(CryptoSEO, '0x0000000000000000000000000000000000000000', "0x07389e110b741b60466f71e40f9643ef1341bc01", "0854301f6f6c4d2a974d54ea1a57d441")
+    deployer.deploy(CryptoSEO, 
+      '0x0000000000000000000000000000000000000000', 
+      process.env.ORACLE_ADDR,
+      process.env.SLEEP_JOB_ID,
+      process.env.SEARCH_JOB_ID,
+      process.env.SEARCH_URL)
   }
 };

--- a/src/js/create.js
+++ b/src/js/create.js
@@ -5,7 +5,10 @@ import { Container, Form, Card, Col, InputGroup } from 'react-bootstrap'
 import ModalDialog from './modal'
 
 const LINK_TOKEN_MULTIPLIER = 10**18
-const ORACLE_PAYMENT = 1 * LINK_TOKEN_MULTIPLIER
+//TODO: Be nice to have these amounts in a config file
+const SLEEP_PAYMENT = 0.1 * LINK_TOKEN_MULTIPLIER
+const SEARCH_PAYMENT = 0.1 * LINK_TOKEN_MULTIPLIER
+const LINK_PAYMENT = SLEEP_PAYMENT + SEARCH_PAYMENT
 
 export default class Create extends Component {
     constructor(props){
@@ -73,7 +76,7 @@ export default class Create extends Component {
        let linkBal = await this.getEth().LinkTokenContract.methods.balanceOf(this.getEth().currentAccount).call(
          {from: this.getEth().currentAccount})
  
-       if (linkBal < ORACLE_PAYMENT) {
+       if (linkBal < LINK_PAYMENT) {
          this.showSimpleModal("Insufficient LINK", "This account has insufficient LINK to create this contract")
          return
        }
@@ -127,7 +130,7 @@ export default class Create extends Component {
        }
  
        console.log("About to call approve on LINK token...")
-       this.getEth().LinkTokenContract.methods.approve(this.getEth().CryptoSEOContract._address, String(ORACLE_PAYMENT)).send( 
+       this.getEth().LinkTokenContract.methods.approve(this.getEth().CryptoSEOContract._address, String(LINK_PAYMENT)).send( 
          {from: this.getEth().currentAccount})
          .once('transactionHash', onWaiting)
          .on('error', onError)

--- a/src/js/view.js
+++ b/src/js/view.js
@@ -5,7 +5,7 @@ import ModalDialog from './modal'
 
 const statusCodes = ["Created", "Processing", "Completed"]
 const LINK_TOKEN_MULTIPLIER = 10**18
-const ORACLE_PAYMENT = 1 * LINK_TOKEN_MULTIPLIER
+const SEARCH_PAYMENT = 0.1 * LINK_TOKEN_MULTIPLIER
 
 export default class View extends Component {
     constructor(props) {
@@ -187,7 +187,7 @@ export default class View extends Component {
         let linkBal = await this.getEth().LinkTokenContract.methods.balanceOf(this.getEth().currentAccount).call(
           {from: this.getEth().currentAccount})
   
-        if (linkBal < ORACLE_PAYMENT) {
+        if (linkBal < SEARCH_PAYMENT) {
           this.showSimpleModal("Insufficient LINK", "This account has insufficient LINK to rerun this contract")
           return
         }
@@ -233,7 +233,7 @@ export default class View extends Component {
         }          
 
         console.log("About to call approve on LINK token...")
-        this.getEth().LinkTokenContract.methods.approve(this.getEth().CryptoSEOContract._address, String(ORACLE_PAYMENT)).send( 
+        this.getEth().LinkTokenContract.methods.approve(this.getEth().CryptoSEOContract._address, String(SEARCH_PAYMENT)).send( 
             {from: this.getEth().currentAccount})
             .once('transactionHash', this.txWaiting)
             .on('error', this.txError)

--- a/test/CryptoSEO_rerun_test.js
+++ b/test/CryptoSEO_rerun_test.js
@@ -24,7 +24,9 @@ contract('CryptoSEO rerun', accounts => {
   }
 
   const zeroAddr = '0x0000000000000000000000000000000000000000'
-  const initOraclePayment = 10 ** 18
+  const sleepPayment = 0.1 * 10 ** 18
+  const searchPayment = 0.1 * 10 ** 18
+  const linkPayment = sleepPayment + searchPayment  
   var BN = web3.utils.BN
 
   let link, oc, cc
@@ -32,7 +34,7 @@ contract('CryptoSEO rerun', accounts => {
   beforeEach(async () => {
     link = await LinkToken.new({ from: defaultAccount })
     oc = await Oracle.new(link.address, { from: defaultAccount })
-    cc = await CryptoSEO.new(link.address, oc.address, "000", { from: consumer })
+    cc = await CryptoSEO.new(link.address, oc.address, "001", "002", "http://test.com", { from: consumer })
     await oc.setFulfillmentPermission(oracleNode, true, {
       from: defaultAccount,
     })
@@ -41,7 +43,7 @@ contract('CryptoSEO rerun', accounts => {
   describe('#rerunExpiredCommitment', () => {
     beforeEach(async () => {
       let updatedTimeToExecute = (await time.latest()).add(new BN(60 * 60 * 24 * 30)) // Need to keep this updated relative to latest block as we increase time in tests
-      await link.approve(cc.address, String(initOraclePayment), {from: defaultAccount})
+      await link.approve(cc.address, String(linkPayment), {from: defaultAccount})
       await cc.createSEOCommitment(validCommitment.site, validCommitment.searchTerm, validCommitment.domainMatch, validCommitment.initialSearchRank,
         validCommitment.amtPerRankEth, validCommitment.maxPayableEth, String(updatedTimeToExecute), validCommitment.payee, {
           from: defaultAccount,
@@ -51,16 +53,11 @@ contract('CryptoSEO rerun', accounts => {
 
     context('when called with an expired commitment id', () => {
       it('executes the commitment again', async () => {
-        let requestEvent = (await cc.getPastEvents('RequestGoogleSearchSent'))[0]
-        let reqId = requestEvent.returnValues.requestId
         await time.increase((60 * 60 * 24 * 31))
-        await link.approve(cc.address, String(initOraclePayment), {from: defaultAccount})
+        await link.approve(cc.address, String(searchPayment), {from: defaultAccount})
         await cc.rerunExpiredCommitment(0)
 
-        let searchReq = await cc.requestMap(reqId)
-        assert.equal(searchReq.isValue, false)
-
-        requestEvent = (await cc.getPastEvents('RequestGoogleSearchSent'))[0]
+        requestEvent = (await cc.getPastEvents('RequestSearchSent'))[0]
         assert.equal(requestEvent.returnValues.commitmentId, 0)
 
         reqId = requestEvent.returnValues.requestId
@@ -75,7 +72,7 @@ contract('CryptoSEO rerun', accounts => {
 
     context('when called with an invalid commitment id', () => {
       it('fails to rerun the commitment', async () => {
-        await link.approve(cc.address, String(initOraclePayment), {from: defaultAccount})
+        await link.approve(cc.address, String(searchPayment), {from: defaultAccount})
         await expectRevert(cc.rerunExpiredCommitment(50), "No commitment for that commitmentId")
       })
     })

--- a/test/CryptoSEO_simple_test.js
+++ b/test/CryptoSEO_simple_test.js
@@ -13,10 +13,12 @@ contract('CryptoSEO simple', accounts => {
   const consumer = accounts[3]
 
   const zeroAddr = '0x0000000000000000000000000000000000000000'
-  const searchJobId = "000"
-  const newJobId = "001"
+  const initSleepJobId = "001"
+  const initSearchJobId = "002"
+  const initSearchUrl = "http://test.com"
   const initReqExpiry = 60 * 60 // (1 hour)
-  const initOraclePayment = 10 ** 18
+  const initSleepPayment = 0.1 * 10 ** 18
+  const initSearchPayment = 0.1 * 10 ** 18
   const payment = web3.utils.toWei('1', 'ether')
   var BN = web3.utils.BN
 
@@ -25,7 +27,7 @@ contract('CryptoSEO simple', accounts => {
   beforeEach(async () => {
     link = await LinkToken.new({ from: defaultAccount })
     oc = await Oracle.new(link.address, { from: defaultAccount })
-    cc = await CryptoSEO.new(link.address, oc.address, "000", { from: consumer })
+    cc = await CryptoSEO.new(link.address, oc.address, initSleepJobId, initSearchJobId, initSearchUrl, { from: consumer })
     await oc.setFulfillmentPermission(oracleNode, true, {
       from: defaultAccount,
     })
@@ -49,20 +51,38 @@ contract('CryptoSEO simple', accounts => {
     })
   })
 
-  describe('#setGoogleSearchJobId', () => {
+  describe('#setSleepJobId', () => {
     context('when called by a non-owner', () => {
       it('cannot set job id', async () => {
-        await expectRevert(cc.setGoogleSearchJobId(newJobId, { from: stranger }), "Ownable: caller is not the owner")
+        await expectRevert(cc.setSleepJobId("000", { from: stranger }), "Ownable: caller is not the owner")
       })
     })
 
     context('when called by the owner', () => {
       it('sets the job id', async () => {
-        let jobId = await cc.googleSearchJobId()
-        assert.equal(jobId, searchJobId)
-        await cc.setGoogleSearchJobId(newJobId, { from: consumer })
-        jobId = await cc.googleSearchJobId()
-        assert.equal(jobId, newJobId)
+        let jobId = await cc.sleepJobId()
+        assert.equal(jobId, initSleepJobId)
+        await cc.setSleepJobId("000", { from: consumer })
+        jobId = await cc.sleepJobId()
+        assert.equal(jobId, "000")
+      })
+    })
+  })
+
+  describe('#setSearchJobId', () => {
+    context('when called by a non-owner', () => {
+      it('cannot set job id', async () => {
+        await expectRevert(cc.setSearchJobId("000", { from: stranger }), "Ownable: caller is not the owner")
+      })
+    })
+
+    context('when called by the owner', () => {
+      it('sets the job id', async () => {
+        let jobId = await cc.searchJobId()
+        assert.equal(jobId, initSearchJobId)
+        await cc.setSearchJobId("000", { from: consumer })
+        jobId = await cc.searchJobId()
+        assert.equal(jobId, "000")
       })
     })
   })
@@ -85,23 +105,59 @@ contract('CryptoSEO simple', accounts => {
     })
   })
 
-  describe('#setOraclePayment', () => {
+  describe('#setSleepPayment', () => {
     context('when called by a non-owner', () => {
-      it('cannot set the oracle payment', async () => {
-        await expectRevert(cc.setOraclePayment(0, { from: stranger }), "Ownable: caller is not the owner")
+      it('cannot set the sleep payment', async () => {
+        await expectRevert(cc.setSleepPayment(0, { from: stranger }), "Ownable: caller is not the owner")
       })
     })
 
     context('when called by the owner', () => {
-      it('sets the oracle payment', async () => {
-        let oraclePmt = await cc.ORACLE_PAYMENT()
-        assert.equal(oraclePmt, initOraclePayment)
-        await cc.setOraclePayment(0, { from: consumer })
-        oraclePmt = await cc.ORACLE_PAYMENT()
+      it('sets the sleep payment', async () => {
+        let sleepPmt = await cc.SLEEP_PAYMENT()
+        assert.equal(sleepPmt, initSleepPayment)
+        await cc.setSleepPayment(0, { from: consumer })
+        oraclePmt = await cc.SLEEP_PAYMENT()
         assert.equal(oraclePmt, 0)
       })
     })
   })
+
+  describe('#setSearchPayment', () => {
+    context('when called by a non-owner', () => {
+      it('cannot set the search payment', async () => {
+        await expectRevert(cc.setSearchPayment(0, { from: stranger }), "Ownable: caller is not the owner")
+      })
+    })
+
+    context('when called by the owner', () => {
+      it('sets the search payment', async () => {
+        let oraclePmt = await cc.SEARCH_PAYMENT()
+        assert.equal(oraclePmt, initSearchPayment)
+        await cc.setSearchPayment(0, { from: consumer })
+        oraclePmt = await cc.SEARCH_PAYMENT()
+        assert.equal(oraclePmt, 0)
+      })
+    })
+  })  
+
+  describe('#setSearchUrl', () => {
+    context('when called by a non-owner', () => {
+      it('cannot set the search URL', async () => {
+        await expectRevert(cc.setSearchUrl("http://new.com", { from: stranger }), "Ownable: caller is not the owner")
+      })
+    })
+
+    context('when called by the owner', () => {
+      it('sets the search URL', async () => {
+        let searchUrl = await cc.searchUrl()
+        assert.equal(searchUrl, initSearchUrl)
+        await cc.setSearchUrl("http://new.com", { from: consumer })
+        searchUrl = await cc.searchUrl()
+        assert.equal(searchUrl, "http://new.com")
+      })
+    })
+  }) 
 
   describe('#withdrawEther', () => {
     beforeEach(async () => {


### PR DESCRIPTION
This PR is quite a big change to the contract, essentially changing things so there is no need for the custom googlesearch action and job anymore. The search adapter now supports GET requests, which means we can use a standard GET -> Uint256 chainlink job.

Unfortunately as no one supports the sleep in the same job we now need to run it as a separate job, which means we need to call two different chainlink jobs and the contract is a little more complicated. Tests have been updated and they all seem to pass though.